### PR TITLE
Feature/cheating function [redundant, new branch: Expose cheating players]

### DIFF
--- a/app/src/main/java/com/ss20/se2/monopoly/DeedManager.java
+++ b/app/src/main/java/com/ss20/se2/monopoly/DeedManager.java
@@ -35,6 +35,11 @@ public class DeedManager implements Serializable{
 		return player.getBalance();
 	}
 
+	public void cheatStreet(Deed deed, Player player){
+		player.addDeedToPlayer(deed);
+		deed.setOwner(player);
+	}
+
 	public int performAcquiringHouseFor(Street street, Player player) {
 		if (street.getHousePrice() <= player.getBalance() && street.getHouseCount() < 4) {
 			int newBalance = player.getBalance() - street.getHousePrice();

--- a/app/src/main/java/com/ss20/se2/monopoly/view/GameboardActivity.java
+++ b/app/src/main/java/com/ss20/se2/monopoly/view/GameboardActivity.java
@@ -347,6 +347,7 @@ public class GameboardActivity extends AppCompatActivity implements DeedFragment
 			dialog.show();
 			communityCardProcessor.performAction(player, communityCard);
 			view_balance.setText("Balance: " + player.getBalance());
+			playerFinishedTurn();
 		}else if (currentTile instanceof ChanceCard){
 			ChanceCard chanceCard = chanceCards.getNextCard();
 			AlertDialog dialog = new AlertDialog.Builder(GameboardActivity.this).create();
@@ -362,6 +363,7 @@ public class GameboardActivity extends AppCompatActivity implements DeedFragment
 			dialog.show();
 			chanceCardProcessor.performAction(player, chanceCard);
 			view_balance.setText("Balance: " + player.getBalance());
+			playerFinishedTurn();
 		}
 	}
 

--- a/app/src/main/java/com/ss20/se2/monopoly/view/GameboardActivity.java
+++ b/app/src/main/java/com/ss20/se2/monopoly/view/GameboardActivity.java
@@ -59,6 +59,8 @@ public class GameboardActivity extends AppCompatActivity implements DeedFragment
 	TextView view_balance;
 	TextView updateBalance;
 	Button altbutton;
+	Button cheatButton;
+	ImageView middleTile;
 
 	Dice dice = new Dice();
 	Dice dice2 = new Dice();
@@ -149,6 +151,8 @@ public class GameboardActivity extends AppCompatActivity implements DeedFragment
 		view_balance = findViewById(R.id.text_balance);
 		updateBalance = findViewById(R.id.changeOfBalance);
 		altbutton = findViewById(R.id.altbutton);
+		cheatButton = findViewById(R.id.button_cheat);
+		middleTile = findViewById(R.id.tile_middle);
 
 
 		button_rollDice.setOnClickListener(new View.OnClickListener() {
@@ -205,11 +209,30 @@ public class GameboardActivity extends AppCompatActivity implements DeedFragment
 						processRoll();
 						findViewById(R.id.playericon).setX(fields[gameboard.getPosition("Player 1")].getX());
 						findViewById(R.id.playericon).setY(fields[gameboard.getPosition("Player 1")].getY());
+
+
+						GameTile currentTile = gameboard.gameTiles.get(currentPlayer.getCurrentPosition());
+
+						if(currentTile instanceof Street){
+							final Street street = (Street) currentTile;
+							if(street.getOwner() == null){
+								middleTile.setOnClickListener(new View.OnClickListener() {
+									@Override
+									public void onClick(View v) {
+										cheatButton.setVisibility(View.VISIBLE);
+										middleTile.setOnClickListener(null);
+									}
+
+								});
+							}
+						}
+
 					}
 				});
 
 				Objects.requireNonNull(mSensorManager).registerListener(mSensorListener, mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
 						SensorManager.SENSOR_DELAY_GAME);
+				cheatButton.setVisibility(View.INVISIBLE);
 				}
 		});
 		button_buyOut.setOnClickListener(new View.OnClickListener(){
@@ -220,6 +243,17 @@ public class GameboardActivity extends AppCompatActivity implements DeedFragment
 				int balance = currentPlayer.getBalance();
 				view_balance.setText(getString(R.string.balance, balance));
 				showDifference(getOldBalance(), currentPlayer.getBalance());
+			}
+		});
+
+		cheatButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+
+				GameTile currentTile = gameboard.gameTiles.get(currentPlayer.getCurrentPosition());
+
+				cheat(currentPlayer, (Street) currentTile);
+				cheatButton.setVisibility(View.INVISIBLE);
 			}
 		});
 		setup();

--- a/app/src/main/java/com/ss20/se2/monopoly/view/GameboardActivity.java
+++ b/app/src/main/java/com/ss20/se2/monopoly/view/GameboardActivity.java
@@ -655,6 +655,22 @@ public class GameboardActivity extends AppCompatActivity implements DeedFragment
 		}
 	}
 
+	public void cheat(Player player, Street street){
+
+		deedManager.cheatStreet(street, player);
+		GameState.getInstance().getDeedManager().cheatStreet(street, player);
+		GameState.getInstance().updatePlayer(player);
+		GameState.getInstance().playerEndedTurn();
+		GameStateNetworkMessage message = new GameStateNetworkMessage();
+		message.setState(GameState.getInstance());
+		sendMessage(message);
+
+		Toast.makeText(this, "You now own " + street.getName(), Toast.LENGTH_SHORT).show();
+
+		playerFinishedTurn();
+	}
+
+
 	public int getOldBalance(){
 		return oldBalance;
 	}

--- a/app/src/main/res/layout/gameboard_activity.xml
+++ b/app/src/main/res/layout/gameboard_activity.xml
@@ -548,5 +548,23 @@
             app:layout_constraintTop_toBottomOf="@+id/altbutton"
             app:layout_constraintBottom_toBottomOf="@+id/number_playerposition"
             app:layout_constraintStart_toEndOf="@+id/view_background" />
+    <Button
+            android:text="Cheat!"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/button_cheat" app:layout_constraintTop_toTopOf="@+id/number_playerposition"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/tile_35" android:visibility="invisible" android:enabled="true"
+            app:layout_constraintHorizontal_bias="0.507"/>
+    <Button
+            android:text="Expose!"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/button_expose"
+            app:layout_constraintTop_toBottomOf="@+id/button_cheat" app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_bias="0.242" app:layout_constraintVertical_bias="0.0"
+            app:layout_constraintEnd_toEndOf="@+id/button_cheat"
+            app:layout_constraintStart_toStartOf="@+id/button_cheat"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
In this PR a player is able to cheat with the following steps:
- after going on a street the player needs to dismiss the buy menu
- then he needs to click the middle tile of the gameboard to activate the cheat button
- a cheat button will appear
- pressing the cheat button will acquire the current street (only if it has no owner of course)
- cheat button will turn invisible and turn is over
---------------------------------------------------------

The ability to expose cheating players will be added in a new branch 